### PR TITLE
added recall bias method

### DIFF
--- a/R/mess-up-linelist.R
+++ b/R/mess-up-linelist.R
@@ -32,6 +32,79 @@ add_missing <- function(ll, prop = 0.2, threshold_days = 0L) {
     )
 }
 
+##' Add recall-biased missingness to onset dates
+##'
+##' Introduce missingness in `date_onset` such that older onset dates are less
+##' likely to be retained. The probability that an onset date is observed follows
+##' a logistic curve as a function of the delay between onset and admission.
+##'
+##' The curve is parameterised using two interpretable anchors:
+##' - at `day_90_observed`, approximately 90% of onset dates are still observed
+##' - at `day_50_observed`, approximately 50% of onset dates are still observed
+##'
+##' @param ll Line list data frame containing `date_onset` and `date_admission`
+##'   as Date columns.
+##' @param day_90_observed Delay in days at which approximately 90% of onset
+##'   dates are still observed.
+##' @param day_50_observed Delay in days at which approximately 50% of onset
+##'   dates are still observed.
+##' @param rng_seed Optional integer for reproducible random number generation.
+##'
+##' @return A data frame with the same columns as the input line list, with
+##'   recall-biased missingness introduced into `date_onset`.
+add_recall_missing <- function(ll,
+                               day_90_observed = 7,
+                               day_50_observed = 21,
+                               rng_seed = NULL) {
+  if (!is.null(rng_seed)) {
+    set.seed(rng_seed)
+  }
+
+  if (day_90_observed >= day_50_observed) {
+    stop("day_90_observed must be smaller than day_50_observed.")
+  }
+
+  ll |>
+    mutate(
+      # Delay between the true onset date and the admission date.
+      # Larger delays correspond to worse recall.
+      delay_recall = as.integer(date_admission - date_onset),
+
+      # Keep missing delays as NA and truncate negative delays at zero.
+      delay_recall = if_else(
+        is.na(delay_recall),
+        NA_integer_,
+        pmax(delay_recall, 0L)
+      ),
+
+      # Probability that the onset date is still observed.
+      # By construction:
+      # - p_observed_recall(day_90_observed) ~= 0.9
+      # - p_observed_recall(day_50_observed) ~= 0.5
+      p_observed_recall = plogis(
+        qlogis(0.9) +
+          (delay_recall - day_90_observed) *
+          (qlogis(0.5) - qlogis(0.9)) /
+          (day_50_observed - day_90_observed)
+      ),
+
+      # Draw one random number per row to decide whether the onset date is kept.
+      u = runif(n()),
+
+      # Remove the onset date if the random draw exceeds the probability that
+      # the date is still observed.
+      remove_onset = !is.na(p_observed_recall) & u > p_observed_recall,
+
+      # Set onset dates selected for removal to missing.
+      date_onset = if_else(
+        remove_onset,
+        as.Date(NA_character_),
+        date_onset
+      )
+    ) |>
+    select(-delay_recall, -p_observed_recall, -u, -remove_onset)
+}
+
 ##' Add noise to dates (due to poor recall)
 ##'
 ##' @param noise_func Function to generate the noise; this should have two

--- a/vignettes/issue_recall_bias_approaches.Rmd
+++ b/vignettes/issue_recall_bias_approaches.Rmd
@@ -1,0 +1,302 @@
+---
+title: "Estimating delays under recall-biased symptom onset reporting"
+---
+
+## Setup
+```{r}
+knitr::opts_chunk$set(cache = FALSE)
+library(dplyr)
+library(ggplot2)
+source(here::here("R", "mess-up-linelist.R"))
+source(here::here("R", "messy-linelist.R"))
+
+library(primarycensored)
+library(cmdstanr)
+```
+
+## Primarycensored setup
+```{r}
+pcd_model <- pcd_cmdstan_model(cpp_options = list(stan_threads = FALSE))
+```
+```{r}
+pcd_data_function <- function(delay_data) {
+  pcd_data <- pcd_as_stan_data(
+    delay_data,
+    delay = "observed_delay",
+    delay_upper = "observed_delay_upper",
+    relative_obs_time = "D",
+    pwindow = "pwindow",
+    dist_id = pcd_stan_dist_id("lognormal", "delay"),
+    primary_id = pcd_stan_dist_id("uniform", "primary"),
+    param_bounds = list(lower = c(-Inf, 0), upper = c(Inf, Inf)),
+    primary_param_bounds = list(lower = numeric(0), upper = numeric(0)),
+    priors = list(location = c(1, 0.5), scale = c(1, 0.5)),
+    primary_priors = list(location = numeric(0), scale = numeric(0)),
+    use_reduce_sum = FALSE # use within chain parallelisation
+  )
+}
+```
+
+## Data preparation
+```{r}
+ll_clean <- readr::read_csv(here::here("data-raw", "clean_linelist.csv")) |>
+  filter(asymptomatic == FALSE, !is.na(date_onset), !is.na(date_admission))
+
+day_90_observed <- 1
+day_50_observed <- 7
+day_10_observed <- 2 * day_50_observed - day_90_observed
+
+ll_recall <- add_recall_missing(
+  ll_clean,
+  day_90_observed = day_90_observed,
+  day_50_observed = day_50_observed,
+  rng_seed = 2026
+)
+
+ll <- new_messy_linelist(ll_clean)
+ll[, date_onset := ll_recall$date_onset]
+```
+
+## The recall bias mechanism
+```{r}
+recall_curve <- data.frame(
+  true_delay = 0:max(as.numeric(ll$date_admission_true - ll$date_onset_true), na.rm = TRUE)
+) |>
+  mutate(
+    p_observed_recall = plogis(
+      qlogis(0.9) +
+        (true_delay - day_90_observed) *
+        (qlogis(0.5) - qlogis(0.9)) /
+        (day_50_observed - day_90_observed)
+    )
+  )
+
+recall_empirical <- ll |>
+  transmute(
+    true_delay = as.numeric(date_admission_true - date_onset_true),
+    onset_observed = !is.na(date_onset)
+  ) |>
+  filter(true_delay >= 0) |>
+  group_by(true_delay) |>
+  summarise(
+    p_observed_empirical = mean(onset_observed),
+    n = n(),
+    .groups = "drop"
+  )
+
+ggplot() +
+  geom_line(
+    data = recall_curve,
+    aes(x = true_delay, y = p_observed_recall),
+    linewidth = 1.1,
+    color = "#125c87"
+  ) +
+  geom_point(
+    data = recall_empirical,
+    aes(x = true_delay, y = p_observed_empirical, size = n),
+    color = "#a00000",
+    alpha = 0.7
+  ) +
+  geom_vline(xintercept = c(day_90_observed, day_50_observed, day_10_observed),
+             linetype = c("dashed", "dashed", "dotted"),
+             color = c("#125c87", "#800000", "grey40")) +
+  theme_bw() +
+  labs(
+    x = "True onset-to-admission delay (days)",
+    y = "Probability onset date is observed",
+    size = "Records"
+  )
+```
+
+## Comparing approaches to recall bias
+
+### Unsuitable approach 1: Complete-case analysis
+```{r}
+delay_data <- ll |>
+  filter(!is.na(date_onset)) |>
+  mutate(delay = as.numeric(date_admission - date_onset)) |>
+  filter(delay >= 0) |>
+  group_by(delay) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = 1,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+  )
+
+pcd_fit_complete_case <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2,
+  threads_per_chain = 2,
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+### Unsuitable approach 2: Ad-hoc imputation using date of report
+```{r}
+ll_impute_report <- data.table::copy(ll)
+do_impute_from_other(ll_impute_report, "date_onset", "date_reporting")
+
+delay_data <- ll_impute_report |>
+  mutate(delay = as.numeric(date_admission - date_onset)) |>
+  filter(delay >= 0) |>
+  group_by(delay) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = 1,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+  )
+
+pcd_fit_impute_report <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2,
+  threads_per_chain = 2,
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+### Suitable approach 1: Broad censoring model
+Assume missing onset dates are only known to have happened within 8 weeks before
+admission.
+```{r}
+delay_data <- ll |>
+  mutate(
+    earliest_onset_date = date_admission - day_10_observed,
+    latest_onset_date = date_admission
+  ) |>
+  mutate(
+    delay = as.numeric(date_admission - if_else(is.na(date_onset), earliest_onset_date, date_onset)),
+    pwindow = if_else(is.na(date_onset), as.numeric(latest_onset_date - earliest_onset_date) + 1, 1)
+  ) |>
+  filter(delay >= 0) |>
+  group_by(delay, pwindow) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = pwindow,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+  )
+
+pcd_fit_censor_broad <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2,
+  threads_per_chain = 2,
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+### Suitable approach 2: Recall-informed sensitivity analysis
+Use the assumed recall curve to define a tighter onset window. Under the
+logistic recall model, the day at which only 10% of dates are still observed is
+`2 * day_50_observed - day_90_observed`.
+```{r}
+delay_data <- ll |>
+  mutate(
+    earliest_onset_date = date_admission - day_10_observed,
+    latest_onset_date = date_admission
+  ) |>
+  mutate(
+    delay = as.numeric(date_admission - if_else(is.na(date_onset), earliest_onset_date, date_onset)),
+    pwindow = if_else(is.na(date_onset), as.numeric(latest_onset_date - earliest_onset_date) + 1, 1)
+  ) |>
+  filter(delay >= 0) |>
+  group_by(delay, pwindow) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = pwindow,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+  )
+
+pcd_fit_censor_recall <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2,
+  threads_per_chain = 2,
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+## Results
+```{r}
+pcd_fit_truth <- pcd_model$sample(
+  data = ll_clean |>
+    mutate(delay = as.numeric(date_admission - date_onset)) |>
+    filter(delay >= 0) |>
+    group_by(delay) |>
+    summarise(n = n()) |>
+    ungroup() |>
+    transmute(
+      observed_delay = delay,
+      observed_delay_upper = delay + 1,
+      pwindow = 1,
+      D = max(delay, na.rm = TRUE) + 2,
+      n = n
+    ) |>
+    pcd_data_function(),
+  chains = 4,
+  parallel_chains = 2,
+  threads_per_chain = 2,
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+```{r}
+rvars <- lapply(
+  list(
+    pcd_fit_complete_case,
+    pcd_fit_impute_report,
+    pcd_fit_censor_broad,
+    pcd_fit_censor_recall
+  ),
+  function(x) posterior::as_draws_rvars(x$draws("params"))
+)
+
+truth_mean_delay <- pcd_fit_truth$summary(c("params[1]", "params[2]"))
+truth_mean_delay <- exp(truth_mean_delay$mean[1] + truth_mean_delay$mean[2]^2 / 2)
+
+results_df <- data.frame(
+  Estimate = forcats::fct_inorder(c(
+    "Complete cases\n(unsuitable)",
+    "Report-date imputation\n(unsuitable)",
+    "Broad censoring window\n(suitable)",
+    "Recall-informed bound\n(suitable)"
+  )),
+  mean_delay = t(do.call(cbind, lapply(
+    rvars,
+    function(x) exp(x$params[[1]] + x$params[[2]]^2 / 2)
+  )))
+)
+
+ggplot(results_df) +
+  ggdist::stat_halfeye(aes(fill = Estimate, color = Estimate, xdist = mean_delay), alpha = 0.6) +
+  geom_vline(xintercept = truth_mean_delay, color = "black", linetype = "dashed") +
+  scale_color_manual(values = c("#800000", "orange", "#125c87", "#2A9D8F")) +
+  scale_fill_manual(values = c("#a00000", "orange", "#1a80bb", "#2A9D8F")) +
+  theme_bw() +
+  theme(legend.position = "top") +
+  labs(x = "Mean delay (days)", y = "Density")
+
+# ggsave(here::here("vignettes", "figures", "issue_recall_bias_approaches.png"), width = 10, height = 6)
+```

--- a/vignettes/issue_recall_bias_missingness.Rmd
+++ b/vignettes/issue_recall_bias_missingness.Rmd
@@ -1,0 +1,222 @@
+---
+title: "Estimating delays from line list data with recall-biased missing symptom onset date"
+---
+
+## Setup
+```{r}
+knitr::opts_chunk$set(cache = TRUE)
+library(dplyr)
+library(ggplot2)
+source(here::here("R", "mess-up-linelist.R"))
+source(here::here("R", "messy-linelist.R"))
+
+library(primarycensored)
+library(cmdstanr)
+```
+
+## Primarycensored setup
+```{r}
+pcd_model <- pcd_cmdstan_model(cpp_options = list(stan_threads = FALSE))
+```
+```{r}
+pcd_data_function <- function(delay_data) {
+  pcd_data <- pcd_as_stan_data(
+    delay_data,
+    delay = "observed_delay",
+    delay_upper = "observed_delay_upper",
+    relative_obs_time = "D",
+    pwindow = "pwindow",
+    dist_id = pcd_stan_dist_id("lognormal", "delay"),
+    primary_id = pcd_stan_dist_id("uniform", "primary"),
+    param_bounds = list(lower = c(-Inf, 0), upper = c(Inf, Inf)),
+    primary_param_bounds = list(lower = numeric(0), upper = numeric(0)),
+    priors = list(location = c(1, 0.5), scale = c(1, 0.5)),
+    primary_priors = list(location = numeric(0), scale = numeric(0)),
+    use_reduce_sum = FALSE # use within chain parallelisation
+  )
+}
+```
+
+## Data preparation
+```{r}
+ll_clean <- readr::read_csv(here::here("data-raw", "clean_linelist.csv"))
+```
+
+Some checking
+```{r}
+# date_reporting occur before date_onset
+
+ll_clean |>
+  filter(date_reporting < date_onset) |> 
+  nrow()
+```
+
+
+Setup a messy linelist
+
+(This is missing not at random, with probability of missingness increasing with
+the delay between onset and admission.)
+
+```{r}
+ll_recall <- add_recall_missing(
+  ll_clean,
+  day_90_observed = 1,
+  day_50_observed = 3,
+  rng_seed = 2026
+)
+
+ll <- new_messy_linelist(ll_recall)
+```
+
+## Estimating the onset to admission delay distribution
+
+### Messy analysis: Imputed using the date of report
+```{r}
+ll_messy <- data.table::copy(ll)
+do_impute_from_other(ll_messy, "date_onset", "date_reporting")
+
+delay_data <- ll_messy |> 
+  mutate(delay = as.numeric(date_admission - date_onset)) |>
+  filter(delay >= 0) |>
+  group_by(delay) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = 1,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+    )
+
+pcd_fit_messy <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2, # Run 2 chains in parallel
+  threads_per_chain = 2, # Use 2 cores per chain
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+### Messy analysis 2: Only symptomatic, but still imputed using the date of report
+```{r}
+ll_messy2 <- data.table::copy(ll)
+do_impute_from_other(ll_messy2, "date_onset", "date_reporting")
+
+delay_data <- ll_messy2 |> 
+  filter(asymptomatic == FALSE) |> 
+  mutate(delay = as.numeric(date_admission - date_onset)) |>
+  filter(delay >= 0) |>
+  group_by(delay) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = 1,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+    )
+
+pcd_fit_messy2 <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2, # Run 2 chains in parallel
+  threads_per_chain = 2, # Use 2 cores per chain
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+### Messy analysis 3:
+
+Compute a mean_delay = date_reporting - date_onset of non-missing cases
+
+Impute date_onset by date_reporting - mean_delay
+
+```{r}
+ll_messy3 <- data.table::copy(ll)
+do_impute_with_mean_delay(ll_messy3, "date_onset", "date_reporting")
+
+delay_data <- ll_messy3 |> 
+  mutate(delay = as.numeric(date_admission - date_onset)) |>
+  filter(delay >= 0) |>
+  group_by(delay) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = 1,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+    )
+
+pcd_fit_messy3 <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2, # Run 2 chains in parallel
+  threads_per_chain = 2, # Use 2 cores per chain
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+
+### Correct analysis
+do not impute, instead assume:
+- earliest onset: earliest onset date in dataset, but not earlier than 8 weeks before admission
+- latest onset: maximum of date of admission / date of report
+- date of admission: known (1 day censoring)
+```{r}
+delay_data <- ll |> 
+  filter(asymptomatic == FALSE) |>
+  mutate(
+    earliest_onset_date = pmax(min(date_onset, na.rm = TRUE), date_admission - 7*4*2),
+    latest_onset_date = pmax(date_admission, date_reporting, na.rm = TRUE)
+  ) |> 
+  mutate(delay = as.numeric(date_admission - ifelse(is.na(date_onset), earliest_onset_date, date_onset))) |>
+  mutate(pwindow = ifelse(is.na(date_onset), as.numeric(latest_onset_date - earliest_onset_date) + 1, 1)) |> 
+  filter(delay >= 0) |>
+  group_by(delay, pwindow) |>
+  summarise(n = n()) |>
+  ungroup() |>
+  transmute(
+    observed_delay = delay,
+    observed_delay_upper = delay + 1,
+    pwindow = pwindow,
+    D = max(delay, na.rm = TRUE) + 2,
+    n = n
+    )
+
+pcd_fit_correct <- pcd_model$sample(
+  data = pcd_data_function(delay_data),
+  chains = 4,
+  parallel_chains = 2, # Run 2 chains in parallel
+  threads_per_chain = 2, # Use 2 cores per chain
+  refresh = ifelse(interactive(), 50, 0),
+  show_messages = interactive()
+)
+```
+
+## Results
+```{r}
+rvars <- lapply(list(pcd_fit_messy, pcd_fit_messy2, pcd_fit_messy3, pcd_fit_correct), function(x) posterior::as_draws_rvars(x$draws("params")))
+
+results_df <- data.frame(
+  Estimate = forcats::fct_inorder(c("Ad-hoc imputation\n(with asymptomatic)", "Ad-hoc imputation\n(only symptomatic)", "Ad-hoc imputation\n(subtract mean delay)", "Missingness model\n(only symptomatic)")),
+  mean_delay = t(do.call(cbind, lapply(rvars, function(x) exp(x$params[[1]] + x$params[[2]]^2 / 2))))
+)
+
+ggplot(results_df) +
+  ggdist::stat_halfeye(aes(fill = Estimate, color = Estimate, xdist = mean_delay), alpha = 0.6) +
+  geom_vline(xintercept = exp(1.5 + 0.5^2 / 2), color = "black", linetype = "dashed") +
+  scale_color_manual(values = c("#800000", "orange", "#2A9D8F", "#125c87")) +
+  scale_fill_manual(values = c("#a00000", "orange", "#2A9D8F", "#1a80bb")) +
+  theme_bw() +
+  theme(legend.position = "top") +
+  labs(x = "Mean delay (days)", y = "Density")
+
+# ggsave(here::here("vignettes", "figures", "issue_recall_bias_missingness.png"), width = 10, height = 6)
+```


### PR DESCRIPTION
added a new method to simulate recall bias by removing onset dates with a logistic probability curve dpendent on the length of the delay; added a new vignette for the introduction of recall bais and potential solutions

TODO: i dont have really good solution to solve the introduced bias, one would have to change the delay correction to consider the fact that probality of missingness is dependent on the delay itself